### PR TITLE
Using CGLCONICLIB_CFLAGS to simplify and fix one bug

### DIFF
--- a/configure
+++ b/configure
@@ -5296,7 +5296,12 @@ if test x$prefix = xNONE; then
 else
   full_prefix=$prefix
 fi
-full_prefix=`cd $full_prefix ; pwd`
+# Check whether the path given is absolute.
+# If not, get absolute path
+case $full_prefix in
+     \\/$* | ?:\\/* | NONE | '' ) ;;
+     *) full_prefix=`cd $full_prefix ; pwd` ;;
+esac
 
 abs_lib_dir=$full_prefix/lib
 
@@ -5871,7 +5876,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 5874 "configure"' > conftest.$ac_ext
+  echo '#line 5879 "configure"' > conftest.$ac_ext
   if { (eval echo "$as_me:$LINENO: \"$ac_compile\"") >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7005,7 +7010,7 @@ fi
 
 
 # Provide some information about the compiler.
-echo "$as_me:7008:" \
+echo "$as_me:7013:" \
      "checking for Fortran 77 compiler version" >&5
 ac_compiler=`set X $ac_compile; echo $2`
 { (eval echo "$as_me:$LINENO: \"$ac_compiler --version </dev/null >&5\"") >&5
@@ -8072,11 +8077,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8075: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8080: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8079: \$? = $ac_status" >&5
+   echo "$as_me:8084: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8340,11 +8345,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8343: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8348: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:8347: \$? = $ac_status" >&5
+   echo "$as_me:8352: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -8444,11 +8449,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:8447: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:8452: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:8451: \$? = $ac_status" >&5
+   echo "$as_me:8456: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -10789,7 +10794,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 10792 "configure"
+#line 10797 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -10889,7 +10894,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 10892 "configure"
+#line 10897 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -13233,11 +13238,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:13236: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:13241: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:13240: \$? = $ac_status" >&5
+   echo "$as_me:13245: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -13337,11 +13342,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:13340: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:13345: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:13344: \$? = $ac_status" >&5
+   echo "$as_me:13349: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -14907,11 +14912,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14910: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14915: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:14914: \$? = $ac_status" >&5
+   echo "$as_me:14919: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -15011,11 +15016,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:15014: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:15019: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:15018: \$? = $ac_status" >&5
+   echo "$as_me:15023: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -17218,11 +17223,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:17221: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:17226: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:17225: \$? = $ac_status" >&5
+   echo "$as_me:17230: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -17486,11 +17491,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:17489: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:17494: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:17493: \$? = $ac_status" >&5
+   echo "$as_me:17498: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings other than the usual output.
@@ -17590,11 +17595,11 @@ else
    -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:17593: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:17598: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:17597: \$? = $ac_status" >&5
+   echo "$as_me:17602: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized

--- a/src/CglConicGD1/Makefile.am
+++ b/src/CglConicGD1/Makefile.am
@@ -27,10 +27,11 @@ libConicGD1_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicGD1/Makefile.in
+++ b/src/CglConicGD1/Makefile.in
@@ -377,11 +377,11 @@ libConicGD1_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
-
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicGD2/Makefile.am
+++ b/src/CglConicGD2/Makefile.am
@@ -25,10 +25,11 @@ libConicGD2_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicGD2/Makefile.in
+++ b/src/CglConicGD2/Makefile.in
@@ -374,11 +374,11 @@ libConicGD2_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
-
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicIPM/Makefile.am
+++ b/src/CglConicIPM/Makefile.am
@@ -25,13 +25,14 @@ libConicIPM_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICLP_CFLAGS)\
-	$(CGL_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(COLA_CFLAGS)\
-	$(OSIIPOPT_CFLAGS)
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICLP_CFLAGS)\
+#	$(CGL_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(COLA_CFLAGS)\
+#	$(OSIIPOPT_CFLAGS)
 
 if COIN_HAS_OSIMOSEK
 AM_CPPFLAGS += $(OSIMOSEK_CFLAGS)

--- a/src/CglConicIPM/Makefile.in
+++ b/src/CglConicIPM/Makefile.in
@@ -43,6 +43,13 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICLP_CFLAGS)\
+#	$(CGL_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(COLA_CFLAGS)\
+#	$(OSIIPOPT_CFLAGS)
 @COIN_HAS_OSIMOSEK_TRUE@am__append_1 = $(OSIMOSEK_CFLAGS)
 @COIN_HAS_OSICPLEX_TRUE@am__append_2 = $(OSICPLEX_CFLAGS)
 @IPOPT_IPM_SOLVER_TRUE@am__append_3 = -D__OSI_IPOPT__
@@ -379,9 +386,7 @@ libConicIPM_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS) \
-	$(OSI_CFLAGS) $(OSICLP_CFLAGS) $(CGL_CFLAGS) \
-	$(OSICONIC_CFLAGS) $(COLA_CFLAGS) $(OSIIPOPT_CFLAGS) \
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS) \
 	$(am__append_1) $(am__append_2) $(am__append_3) \
 	$(am__append_4) $(am__append_5)
 

--- a/src/CglConicIPMint/Makefile.am
+++ b/src/CglConicIPMint/Makefile.am
@@ -25,11 +25,12 @@ libConicIPMint_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)\
-	$(OSIMOSEK_CFLAGS)
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)\
+#	$(OSIMOSEK_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicIPMint/Makefile.in
+++ b/src/CglConicIPMint/Makefile.in
@@ -375,12 +375,12 @@ libConicIPMint_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)\
-	$(OSIMOSEK_CFLAGS)
-
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)\
+#	$(OSIMOSEK_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicMIR/Makefile.am
+++ b/src/CglConicMIR/Makefile.am
@@ -25,10 +25,11 @@ libConicMIR_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicMIR/Makefile.in
+++ b/src/CglConicMIR/Makefile.in
@@ -374,11 +374,11 @@ libConicMIR_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
-
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicOA/Makefile.am
+++ b/src/CglConicOA/Makefile.am
@@ -25,10 +25,11 @@ libConicOA_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/CglConicOA/Makefile.in
+++ b/src/CglConicOA/Makefile.in
@@ -374,11 +374,11 @@ libConicOA_la_LDFLAGS = $(LT_LDFLAGS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(CGL_CFLAGS)
-
+AM_CPPFLAGS = -I`$(CYGPATH_W) $(srcdir)/..` $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(CGL_CFLAGS)
 
 # This line is necessary to allow VPATH compilation
 DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)` -I..

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,13 +38,14 @@ libCglConic_la_DEPENDENCIES = $(CGLCONIC_SUBLIBS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = $(COINUTILS_CFLAGS)\
-	$(OSI_CFLAGS)\
-	$(OSICLP_CFLAGS)\
-	$(CGL_CFLAGS)\
-	$(OSICONIC_CFLAGS)\
-	$(COLA_CFLAGS)\
-	$(OSIIPOPT_CFLAGS)
+AM_CPPFLAGS = $(CGLCONICLIB_CFLAGS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICLP_CFLAGS)\
+#	$(CGL_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(COLA_CFLAGS)\
+#	$(OSIIPOPT_CFLAGS)
 
 if COIN_HAS_OSICPLEX
 AM_CPPFLAGS += $(OSICPLEX_CFLAGS)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -44,6 +44,13 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 @DEPENDENCY_LINKING_TRUE@am__append_1 = $(CGLCONICLIB_LIBS)
+#	$(COINUTILS_CFLAGS)\
+#	$(OSI_CFLAGS)\
+#	$(OSICLP_CFLAGS)\
+#	$(CGL_CFLAGS)\
+#	$(OSICONIC_CFLAGS)\
+#	$(COLA_CFLAGS)\
+#	$(OSIIPOPT_CFLAGS)
 @COIN_HAS_OSICPLEX_TRUE@am__append_2 = $(OSICPLEX_CFLAGS)
 @COIN_HAS_OSIMOSEK_TRUE@am__append_3 = $(OSIMOSEK_CFLAGS)
 subdir = src
@@ -397,9 +404,7 @@ libCglConic_la_DEPENDENCIES = $(CGLCONIC_SUBLIBS)
 
 # Here list all include flags, relative to this "srcdir" directory.  This
 # "cygpath" stuff is necessary to compile with native compilers on Windows.
-AM_CPPFLAGS = $(COINUTILS_CFLAGS) $(OSI_CFLAGS) $(OSICLP_CFLAGS) \
-	$(CGL_CFLAGS) $(OSICONIC_CFLAGS) $(COLA_CFLAGS) \
-	$(OSIIPOPT_CFLAGS) $(am__append_2) $(am__append_3)
+AM_CPPFLAGS = $(CGLCONICLIB_CFLAGS) $(am__append_2) $(am__append_3)
 
 # This line is necessary to allow VPATH compilation
 # DEFAULT_INCLUDES = -I. -I`$(CYGPATH_W) $(srcdir)`


### PR DESCRIPTION
You were separately listing the `XXX_CFLAGS` variables for each project, but the intent is that the configure step automatically collects the flags for all dependencies into one variable (in this case `CGLCONICLIB_CFLAGS`). This way, you don't have to muck around with `Makefile.am` whenever you add a dependency. There was one of the sublibraries that didn't have the right list of dependencies (it was missing `OsiIpopt`) and so it wasn't building correctly. This pull request changes to using the `CGLCONICLIB_CFLAGS` everywhere and should simplify maintenance. 
